### PR TITLE
Refactor click/drag command resolution

### DIFF
--- a/kiigame.js
+++ b/kiigame.js
@@ -453,9 +453,9 @@ export class KiiGame {
                 if (dragResolver) {
                     this.handle_commands(dragResolver.resolveCommands(
                         this.interactions,
-                        this.target.id(),
                         dragged_item.id(),
-                        dragged_item.id()
+                        this.target.id(),
+                        this.target.id()
                     ));
                 }
             }

--- a/kiigame.js
+++ b/kiigame.js
@@ -916,7 +916,7 @@ export class KiiGame {
         var target = event.target;
         var target_category = target.getAttr('category');
 
-        var clickResolver = this.clickResolvers.filter(clickResolver => {
+        var clickResolver = this.clickResolvers.filter(function(clickResolver) {
             return clickResolver.getTargetCategory() === target_category;
         });
 

--- a/kiigame.js
+++ b/kiigame.js
@@ -455,7 +455,7 @@ export class KiiGame {
                         this.interactions,
                         this.target.id(),
                         dragged_item.id(),
-                        this.target.id()
+                        dragged_item.id()
                     ));
                 }
             }

--- a/kiigame.js
+++ b/kiigame.js
@@ -446,9 +446,9 @@ export class KiiGame {
             else {
                 var target_category = this.target.getAttr('category');
 
-                var dragResolver = this.dragResolvers.filter(dragResolver => {
+                var dragResolver = this.dragResolvers.filter(function(dragResolver) {
                     return dragResolver.getTargetCategory() == target_category;
-                });
+                }).pop();
 
                 if (dragResolver) {
                     this.handle_commands(dragResolver.resolveCommands(

--- a/kiigame.js
+++ b/kiigame.js
@@ -14,7 +14,7 @@ export class KiiGame {
     constructor(
         jsonGetter = null,
         sequencesBuilder = null,
-        clicResolvers = [],
+        clickResolvers = [],
         dragResolvers = [],
         interactions = null
     ) {

--- a/kiigame.js
+++ b/kiigame.js
@@ -917,7 +917,7 @@ export class KiiGame {
         var target_category = target.getAttr('category');
 
         var clickResolver = this.clickResolvers.filter(clickResolver => {
-            return clickResolver.getTargetCategory() == target_category;
+            return clickResolver.getTargetCategory() === target_category;
         });
 
         if (clickResolver) {

--- a/kiigame.js
+++ b/kiigame.js
@@ -7,12 +7,22 @@ import SequencesBuilder from './view/sequence/konvadata/SequencesBuilder.js';
 import SequenceBuilder from './view/sequence/konvadata/SequenceBuilder.js';
 import SlideBuilder from './view/sequence/konvadata/SlideBuilder.js';
 import TextBuilder from './view/sequence/konvadata/TextBuilder.js';
-
+import DefaultInteractionResolver from './model/DefaultInteractionResolver.js';
+import Interactions from './model/Interactions.js';
 
 export class KiiGame {
-    constructor(jsonGetter = null, sequencesBuilder = null) {
+    constructor(
+        jsonGetter = null,
+        sequencesBuilder = null,
+        clicResolvers = [],
+        dragResolvers = [],
+        interactions = null
+    ) {
         this.jsonGetter = jsonGetter;
         this.sequencesBuilder = sequencesBuilder;
+        this.clickResolvers = clickResolvers;
+        this.dragResolvers = dragResolvers;
+        this.interactions = interactions;
 
         if (this.jsonGetter === null) {
             this.jsonGetter = new JSONGetter();
@@ -24,6 +34,23 @@ export class KiiGame {
                         new TextBuilder()
                     )
                 )
+            );
+        }
+        if (this.clickResolvers.length == 0) {
+            this.clickResolvers.push(
+                new DefaultInteractionResolver('furniture'),
+                new DefaultInteractionResolver('item')
+            );
+        }
+        if (this.dragResolvers.length == 0) {
+            this.dragResolvers.push(
+                new DefaultInteractionResolver('furniture'),
+                new DefaultInteractionResolver('item')
+            );
+        }
+        if (this.interactions === null) {
+            this.interactions = new Interactions(
+                JSON.parse(this.getJSON('interactions.json'))
             );
         }
 
@@ -110,7 +137,6 @@ export class KiiGame {
         this.images_json = JSON.parse(this.getJSON('images.json'));
         this.rooms_json = JSON.parse(this.getJSON('rooms.json'))['rooms'];
         this.texts_json = JSON.parse(this.getJSON('texts.json'));
-        this.interactions_json = JSON.parse(this.getJSON('interactions.json'));
         this.character_json = JSON.parse(this.getJSON('character.json'));
         this.sequences_json = JSON.parse(this.getJSON('sequences.json'));
         this.music_json = JSON.parse(this.getJSON('music.json'));
@@ -417,23 +443,21 @@ export class KiiGame {
                 dragged_item.y(this.dragStartY);
             }
             // Look up the possible interaction from interactions.json.
-            else if (this.target.getAttr('category') == 'furniture' || this.target.getAttr('category') == 'item') {
-                var commands;
+            else {
+                var target_category = this.target.getAttr('category');
 
-                // Not all dragged_items have an entry in interactions_json, or have
-                // anything specified for target_item.
-                try {
-                    commands = this.interactions_json[dragged_item.id()][this.target.id()];
-                } catch (e) {
-                    // Do nothing
+                var dragResolver = this.dragResolvers.filter(dragResolver => {
+                    return dragResolver.getTargetCategory() == target_category;
+                });
+
+                if (dragResolver) {
+                    this.handle_commands(dragResolver.resolveCommands(
+                        this.interactions,
+                        this.target,
+                        dragged_item.id(),
+                        this.target.id()
+                    ));
                 }
-
-                // no dragend interaction defined: usual text
-                if (commands == null) {
-                    commands = [{"command":"monologue", "textkey":{"object": dragged_item.id(), "string": this.target.id()}}];
-                }
-
-                this.handle_commands(commands);
             }
 
             // Check if dragged item's destroyed, if not, add it to inventory
@@ -514,7 +538,6 @@ export class KiiGame {
         this.idle_animation[0].node.show();
         this.idle_animation[0].play();
     }
-
 
     create_animation(object) {
         var attrs = object.getAttr("animation");
@@ -893,25 +916,36 @@ export class KiiGame {
         var target = event.target;
         var target_category = target.getAttr('category');
 
-        if (target_category == 'furniture' || target_category == 'item') {
-            var commands;
+        var clickResolver = this.clickResolvers.filter(clickResolver => {
+            return clickResolver.getTargetCategory() == target_category;
+        });
 
-            // Not all clicked items have their entry in interactions_json.
-            try {
-                commands = this.interactions_json[target.id()].click;
-            } catch (e) {
-                // Do nothing
-            }
-
-            // no click interaction defined: usual examine
-            if (commands == null) {
-                commands = [{"command":"monologue", "textkey":{"object": target.id(), "string": "examine"}}];
-            }
-
-            this.handle_commands(commands);
+        if (clickResolver) {
+            this.handle_commands(clickResolver.resolveCommands(this.interactions, target));
+            return;
         }
-        // Pick up rewards
-        else if (target_category == 'secret') {
+
+        // Inventory arrow buttons
+        if (target.getAttr('id') == 'inventory_left_arrow') {
+            if (target.getAttr('visible') == true) {
+                this.inventory_index--;
+                this.redrawInventory();
+                return;
+            }
+        }
+
+        if (target.getAttr('id') == 'inventory_right_arrow') {
+            if (target.getAttr('visible') == true) {
+                this.inventory_index++;
+                this.redrawInventory();
+                return;
+            }
+        }
+
+        // TODO: Refactor into clickResolvers in latkazombit.js
+        // Everything else except this.rewards++ can be put into interactions.js and use DefaultInteractionResolver
+        // rewards count can be done at game end?
+        if (target_category == 'secret') {
             this.setMonologue(this.findMonologue(target.id(), 'pickup'));
             var rewardID = target.getAttr('reward');
             this.inventoryAdd(this.getObject(rewardID));
@@ -922,21 +956,9 @@ export class KiiGame {
             event.cancelBubble = true;
         }
         // Print examine texts for rewards
+        // TODO: Refactor into its own clickResolver that can use DefaultInteractionResolver
         else if (target_category == 'reward') {
             this.setMonologue(this.findMonologue(target.id()));
-        }
-        // Inventory arrow buttons
-        else if (target.getAttr('id') == 'inventory_left_arrow') {
-            if (target.getAttr('visible') == true) {
-                this.inventory_index--;
-                this.redrawInventory();
-            }
-        }
-        else if (target.getAttr('id') == 'inventory_right_arrow') {
-            if (target.getAttr('visible') == true) {
-                this.inventory_index++;
-                this.redrawInventory();
-            }
         }
     }
 

--- a/kiigame.js
+++ b/kiigame.js
@@ -453,7 +453,7 @@ export class KiiGame {
                 if (dragResolver) {
                     this.handle_commands(dragResolver.resolveCommands(
                         this.interactions,
-                        this.target,
+                        this.target.id(),
                         dragged_item.id(),
                         this.target.id()
                     ));
@@ -921,7 +921,10 @@ export class KiiGame {
         }).pop();
 
         if (clickResolver) {
-            this.handle_commands(clickResolver.resolveCommands(this.interactions, target));
+            this.handle_commands(clickResolver.resolveCommands(
+                this.interactions,
+                target.id()
+            ));
             return;
         }
 

--- a/kiigame.js
+++ b/kiigame.js
@@ -918,7 +918,7 @@ export class KiiGame {
 
         var clickResolver = this.clickResolvers.filter(function(clickResolver) {
             return clickResolver.getTargetCategory() === target_category;
-        });
+        }).pop();
 
         if (clickResolver) {
             this.handle_commands(clickResolver.resolveCommands(this.interactions, target));

--- a/model/DefaultInteractionResolver.js
+++ b/model/DefaultInteractionResolver.js
@@ -18,13 +18,11 @@ class DefaultInteractionResolver {
      * @param string defaultString (examine or dragged item)
      */
     resolveCommands(interactions, targetId, action = 'click', defaultString = 'examine') {
-        console.log(targetId + " " + action + " " + defaultString);
         var commands;
         commands = interactions.getCommands(targetId, action);
-        console.log(commands);
 
         // no interaction for the action defined: usual text
-        if (commands === null) {
+        if (commands === null || commands === undefined) {
             commands = [{"command":"monologue", "textkey":{"object": targetId, "string": defaultString}}];
         }
 

--- a/model/DefaultInteractionResolver.js
+++ b/model/DefaultInteractionResolver.js
@@ -1,0 +1,33 @@
+import Interactions from "./Interactions.js";
+
+/** */
+class DefaultInteractionResolver {
+
+    constructor(targetCategory) {
+        this.targetCategory = targetCategory;
+    }
+
+    getTargetCategory() {
+        return this.targetCategory;
+    }
+
+    /**
+     * @param Interactions interactions
+     * @param string targetId
+     * @param string action (click or dragged item)
+     * @param string defaultString (examine or dragged item)
+     */
+    resolveCommands(interactions, targetId, action = 'click', defaultString = 'examine') {
+        var commands;
+        commands = interactions.getCommands(targetId, action);
+
+        // no interaction for the action defined: usual text
+        if (commands === null) {
+            commands = [{"command":"monologue", "textkey":{"object": targetId, "string": defaultString}}];
+        }
+
+        return commands;
+    }
+}
+
+export default DefaultInteractionResolver;

--- a/model/DefaultInteractionResolver.js
+++ b/model/DefaultInteractionResolver.js
@@ -13,17 +13,17 @@ class DefaultInteractionResolver {
 
     /**
      * @param Interactions interactions
-     * @param string targetId
-     * @param string action (click or dragged item)
-     * @param string defaultString (examine or dragged item)
+     * @param string entityId clicked or dragged item
+     * @param string action (click or target item)
+     * @param string defaultString (examine or target item)
      */
-    resolveCommands(interactions, targetId, action = 'click', defaultString = 'examine') {
+    resolveCommands(interactions, entityID, action = 'click', defaultString = 'examine') {
         var commands;
-        commands = interactions.getCommands(targetId, action);
+        commands = interactions.getCommands(entityID, action);
 
         // no interaction for the action defined: usual text
         if (commands === null || commands === undefined) {
-            commands = [{"command":"monologue", "textkey":{"object": targetId, "string": defaultString}}];
+            commands = [{"command":"monologue", "textkey":{"object": entityID, "string": defaultString}}];
         }
 
         return commands;

--- a/model/DefaultInteractionResolver.js
+++ b/model/DefaultInteractionResolver.js
@@ -18,8 +18,10 @@ class DefaultInteractionResolver {
      * @param string defaultString (examine or dragged item)
      */
     resolveCommands(interactions, targetId, action = 'click', defaultString = 'examine') {
+        console.log(targetId + " " + action + " " + defaultString);
         var commands;
         commands = interactions.getCommands(targetId, action);
+        console.log(commands);
 
         // no interaction for the action defined: usual text
         if (commands === null) {

--- a/model/Interactions.js
+++ b/model/Interactions.js
@@ -1,0 +1,18 @@
+/** */
+class Interactions {
+    constructor(json) {
+        this.json = json;
+    }
+
+    getCommands(entityId, action) {
+        var commands = null;
+        try {
+            commands = this.json[entityId][action];
+        } catch (e) {
+            // Do nothing
+        }
+        return commands;
+    }
+}
+
+export default Interactions;

--- a/test/model/testDefaultInteractionResolver.js
+++ b/test/model/testDefaultInteractionResolver.js
@@ -25,6 +25,18 @@ describe('Test DefaultInteractionResolver', function() {
         assert.deepEqual(expected, result);
     });
 
+    it('returns default examine when Interactions.getCommands returns undefied', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        interactionsStub.getCommands.returns(undefined);
+
+        var target = '1';
+
+        var expected = [{"command":"monologue", "textkey":{"object": "1", "string": "examine"}}];
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target);
+        assert.deepEqual(expected, result);
+    });
+
+
     it('returns something from Interactions for click', function() {
         let defaultInteractionResolver = new DefaultInteractionResolver('test');
         interactionsStub.getCommands.returns('something');

--- a/test/model/testDefaultInteractionResolver.js
+++ b/test/model/testDefaultInteractionResolver.js
@@ -1,0 +1,60 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import DefaultInteractionResolver from '../../model/DefaultInteractionResolver.js';
+import Interactions from '../../model/Interactions.js';
+
+var assert = chai.assert;
+
+var interactionsStub = sinon.createStubInstance(Interactions);
+
+describe('Test DefaultInteractionResolver', function() {
+    it('returns the target category set in constructor', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        var result = defaultInteractionResolver.getTargetCategory();
+        assert.deepEqual('test', result);
+    });
+
+    it('returns default examine when no click commands are found from Interactions', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        interactionsStub.getCommands.returns(null);
+
+        var target = '1';
+
+        var expected = [{"command":"monologue", "textkey":{"object": "1", "string": "examine"}}];
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target);
+        assert.deepEqual(expected, result);
+    });
+
+    it('returns something from Interactions for click', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        interactionsStub.getCommands.returns('something');
+
+        var target = '1';
+        var expected = 'something';
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target);
+        assert.deepEqual(expected, result);
+    });
+
+    it('returns default monologue for item use when no commands are found from Interactions', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        interactionsStub.getCommands.returns(null);
+
+        var target = '1';
+        var draggedItem = '2';
+
+        var expected = [{"command":"monologue", "textkey":{"object": "1", "string": "2"}}];
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target, draggedItem, draggedItem);
+        assert.deepEqual(expected, result);
+    });
+
+    it('returns something from Interactions for item use', function() {
+        let defaultInteractionResolver = new DefaultInteractionResolver('test');
+        interactionsStub.getCommands.returns('something');
+
+        var target = '1';
+        var draggedItem = '2';
+        var expected = 'something';
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target, draggedItem, draggedItem);
+        assert.deepEqual(expected, result);
+    });
+});

--- a/test/model/testDefaultInteractionResolver.js
+++ b/test/model/testDefaultInteractionResolver.js
@@ -54,8 +54,8 @@ describe('Test DefaultInteractionResolver', function() {
         var target = '1';
         var draggedItem = '2';
 
-        var expected = [{"command":"monologue", "textkey":{"object": "1", "string": "2"}}];
-        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target, draggedItem, draggedItem);
+        var expected = [{"command":"monologue", "textkey":{"object": "2", "string": "1"}}];
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, draggedItem, target, target);
         assert.deepEqual(expected, result);
     });
 
@@ -66,7 +66,7 @@ describe('Test DefaultInteractionResolver', function() {
         var target = '1';
         var draggedItem = '2';
         var expected = 'something';
-        var result = defaultInteractionResolver.resolveCommands(interactionsStub, target, draggedItem, draggedItem);
+        var result = defaultInteractionResolver.resolveCommands(interactionsStub, draggedItem, target, target);
         assert.deepEqual(expected, result);
     });
 });

--- a/test/model/testInteractions.js
+++ b/test/model/testInteractions.js
@@ -21,6 +21,16 @@ describe('Test Interactions', function() {
         var action = 'click';
         var expected = null;
         var result = interactions.getCommands(entity, action);
-        assert.deepEqual(expected, result);
+        assert.strictEqual(expected, result);
+    });
+
+    it('will return null when json lookup produces no result', function() {
+        var json = "{\"1\": {\"click\": [{\"command\": \"monologue\",\"textkey\": {\"object\": \"1\", \"string\": \"examine\"}}]}}";
+        let interactions = new Interactions(JSON.parse(json));
+        var entity = '2';
+        var action = 'teddy bear';
+        var expected = null;
+        var result = interactions.getCommands(entity, action);
+        assert.strictEqual(expected, result);
     });
 });

--- a/test/model/testInteractions.js
+++ b/test/model/testInteractions.js
@@ -1,0 +1,26 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import Interactions from '../../model/Interactions.js';
+
+var assert = chai.assert;
+
+describe('Test Interactions', function() {
+    it('will return the single click command', function() {
+        var json = "{\"1\": {\"click\": [{\"command\": \"monologue\",\"textkey\": {\"object\": \"1\", \"string\": \"examine\"}}]}}";
+        let interactions = new Interactions(JSON.parse(json));
+        var entity = '1';
+        var action = 'click';
+        var expected = [{"command":"monologue", "textkey":{"object": '1', "string": "examine"}}];
+        var result = interactions.getCommands(entity, action);
+        assert.deepEqual(expected, result);
+    });
+
+    it('will return null when json lookup fails', function() {
+        let interactions = new Interactions(null);
+        var entity = '1';
+        var action = 'click';
+        var expected = null;
+        var result = interactions.getCommands(entity, action);
+        assert.deepEqual(expected, result);
+    });
+});


### PR DESCRIPTION
Refactor resolving clicks/drags (of game entity objects) into their own classes, with unit testing.

The aim here is to improve architecture so that rewards & secrets can go to Lätkäzombit neatly, instead of the main game engine. It'll also make similar game engine extensions easier to create in cleaner code. This is just one minor step.