### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: Node CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/kiigame/adventure_engine/security/code-scanning/2](https://github.com/kiigame/adventure_engine/security/code-scanning/2)

To fix the issue, we should explicitly add a `permissions` block in the workflow specifying the minimal required privileges. Since the workflow only checks out code, sets up Node.js, installs dependencies, and runs tests (with no steps requiring write access), the correct fix is to set `permissions: contents: read`. The safest place is at the root of the workflow (top-level, before `jobs:`), so all jobs inherit these minimal permissions. Edit the file `.github/workflows/nodejs.yml` to insert a `permissions` block directly under the `name:` declaration (usually after line 1 or 2 and before `on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
