### PR TITLE
refactor(#249): implement room transition view model and a simple character in room model

### DIFF
--- a/src/controller/interactions/CommandHandler.js
+++ b/src/controller/interactions/CommandHandler.js
@@ -59,12 +59,10 @@ class CommandHandler {
             });
             this.gameEventEmitter.emit('add_objects', objectsToAdd);
         } else if (command.command == "do_transition") {
-            if (command.instant) {
-                this.gameEventEmitter.emit('do_instant_transition', {
-                    roomId: command.destination
-                });
-                return;
-            }
+            this.uiEventEmitter.emit('ready_transition', ({
+                type: command.instant ? 'instant' : 'regular',
+                roomId: command.destination
+            }));
             this.gameEventEmitter.emit('do_transition', {
                 roomId: command.destination
             });

--- a/src/kiigame.js
+++ b/src/kiigame.js
@@ -48,6 +48,7 @@ import OtherChildrenBuilder from './viewbuilder/room/konva/OtherChildrenBuilder.
 import ObjectsInRoomsBuilder from './modelbuilder/ObjectsInRoomsBuilder.js';
 import ObjectsInRoomBuilder from './modelbuilder/ObjectsInRoomBuilder.js';
 import ObjectsInRooms from './model/ObjectsInRooms.js';
+import CharacterInRoomViewModel from './view/room/CharacterInRoomViewModel.js';
 
 // TODO: Move DI up
 import "reflect-metadata";
@@ -114,7 +115,7 @@ export class KiiGame {
         ).build(gameData.rooms_json);
         new ObjectsInRooms(initialObjectsInRoomsState, gameEventEmitter);
         // "Player character in room" model
-        new CharacterInRoom(this.uiEventEmitter, this.gameEventEmitter);
+        new CharacterInRoom(this.gameEventEmitter);
         // Inventory model
         this.inventory = new Inventory(this.gameEventEmitter, this.uiEventEmitter);
         // Model end
@@ -265,7 +266,7 @@ export class KiiGame {
         // Sequences view start
         this.sequences_json = gameData.sequences_json;
         this.sequenceLayer = this.stageObjectGetter.getObject('sequence_layer');
-        this.gameEventEmitter.on('arrived_in_room', (_roomId) => {
+        this.uiEventEmitter.on('arrived_in_room', (_roomId) => {
             this.sequenceLayer.hide();
         });
         this.gameEventEmitter.on('play_sequence', (sequence_id) => {
@@ -291,14 +292,15 @@ export class KiiGame {
             new RoomAnimationBuilder(),
             this.stageObjectGetter
         ).build(this.roomView.getRooms());
-        new RoomAnimations(this.gameEventEmitter, animatedRoomObjects);
+        new RoomAnimations(this.gameEventEmitter, this.uiEventEmitter, animatedRoomObjects);
         // Animation for fading the room portion of the screen
         const roomFaderNode = this.stageObjectGetter.getObject("fader_room");
         new RoomFader(
             roomFaderNode,
-            this.uiEventEmitter,
-            this.gameEventEmitter
+            this.uiEventEmitter
         );
+        // Character in room view model
+        new CharacterInRoomViewModel(this.uiEventEmitter, this.gameEventEmitter);
         // Rooms view end
 
         // Inventory & items view start
@@ -312,7 +314,6 @@ export class KiiGame {
         // Inventory view component
         this.inventoryView = new InventoryView(
             this.uiEventEmitter,
-            this.gameEventEmitter,
             this.stageObjectGetter,
             inventoryBarLayer,
             inventoryItemsView

--- a/src/latkazombit.js
+++ b/src/latkazombit.js
@@ -251,7 +251,7 @@ input_layer.on('tap click', function (event) {
 });
 
 // When arriving to the final room (the final step of the game), count rewards in invetory.
-gameEventEmitter.on('arrived_in_room', function (roomId) {
+uiEventEmitter.on('arrived_in_room', function (roomId) {
     if (roomId === 'end_layer') {
         const rewards_text = kiigame.stageObjectGetter.getObject("rewards_text");
         let rewardsCount = 0;

--- a/src/model/CharacterInRoom.js
+++ b/src/model/CharacterInRoom.js
@@ -1,83 +1,15 @@
 class CharacterInRoom {
-    constructor(uiEventEmitter, gameEventEmitter) {
-        this.uiEventEmitter = uiEventEmitter;
+    constructor(gameEventEmitter) {
         this.gameEventEmitter = gameEventEmitter;
-        this.state = {
-            mode: 'NOT_IN_ROOM'
-        };
-        this.uiEventEmitter.on('room_fade_out_done', () => {
-            this.moveCharacterFromTransitToRoom();
-        });
+        this.state = null;
         this.gameEventEmitter.on('do_transition', ({ roomId }) => {
-            this.startTransitionToRoom(roomId);
-        });
-        this.gameEventEmitter.on('do_instant_transition', ({ roomId }) => {
-            this.doInstantTransition(roomId);
+            this.setCharacterInRoomState(roomId);
         });
     }
 
-    /**
-     * Transition to a room.
-     * @param {string} roomId The id of the room to transition to.
-     */
-    startTransitionToRoom(roomId) {
-        if (this.state.mode === 'NOT_IN_ROOM') {
-            this.state = {
-                mode: 'IN_ROOM',
-                room: roomId
-            };
-            this.gameEventEmitter.emit('arriving_in_room');
-            this.gameEventEmitter.emit('arrived_in_room', roomId);
-            return;
-        }
-        if (this.state.mode === 'IN_ROOM') {
-            const from = this.state.room;
-            this.state = {
-                mode: 'IN_TRANSITION',
-                from,
-                to: roomId
-            };
-            this.gameEventEmitter.emit('leaving_room');
-            return;
-        }
-        throw new Error('Doing transition with incompatible CharacterInRoom mode ' + this.state.mode);
-    }
-
-    /**
-     * Transition to a room without ... transitioning.
-     * @param {string} roomId room id to move instantly to
-     */
-    doInstantTransition(roomId) {
-        if (this.state.mode === 'IN_ROOM') {
-            const from = this.state.room;
-            this.gameEventEmitter.emit('left_room', from);
-        }
-        this.state = {
-            mode: 'IN_ROOM',
-            room: roomId
-        };
-        this.gameEventEmitter.emit('arrived_in_room', roomId);
-    }
-
-    /**
-     * Move the character from "in transition" state to the room.
-     * @returns {void}
-     */
-    moveCharacterFromTransitToRoom() {
-        if (this.state.mode === 'IN_TRANSITION') {
-            const from = this.state.from;
-            const room = this.state.to;
-            this.state = {
-                mode: 'IN_ROOM',
-                room
-            };
-            this.gameEventEmitter.emit('left_room', from);
-            this.gameEventEmitter.emit('arriving_in_room');
-            this.gameEventEmitter.emit('arrived_in_room', room);
-            return;
-        }
-
-        throw new Error('Moving character from in transition to room with incompatible mode ' + this.state.mode);
+    setCharacterInRoomState(roomId) {
+        this.state = roomId;
+        this.gameEventEmitter.emit('character_moved_to_room', { roomId });
     }
 };
 

--- a/src/model/CharacterInRoom.test.js
+++ b/src/model/CharacterInRoom.test.js
@@ -4,147 +4,25 @@ import CharacterInRoom from './CharacterInRoom.js';
 import EventEmitter from '../events/EventEmitter.js';
 
 describe('Character in room model tests', () => {
-    let uiEventEmitterStub;
     let gameEventEmitterStub;
     beforeEach(() => {
-        uiEventEmitterStub = createStubInstance(EventEmitter);
         gameEventEmitterStub = createStubInstance(EventEmitter);
     });
-    describe('start transition to room', () => {
-        it('should go from NOT_IN_ROOM to IN_ROOM directly', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            const startTransitionToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+    describe('move character to room', () => {
+        it('should set state and emit event', () => {
+            const characterInRoom = new CharacterInRoom(gameEventEmitterStub);
+            const setCharacterInRoomStateCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'do_transition';
             }).args[1];
-            startTransitionToRoomCallback({ roomId: 'room-id' });
+            setCharacterInRoomStateCallback({ roomId: 'room-id' });
             expect(
                 characterInRoom.state,
                 'state does not match'
-            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
+            ).to.equal('room-id');
             expect(
-                gameEventEmitterStub.emit.calledWith('arriving_in_room'),
-                'arriving_in_room not emitted'
+                gameEventEmitterStub.emit.calledWith('character_moved_to_room', { roomId: 'room-id' }),
+                'character_moved_to_room not emitted with room_id'
             ).to.equal(true);
-            expect(
-                gameEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
-                'arrived_in_room not emitted with room_id'
-            ).to.equal(true);
-        });
-        it('should go from IN_ROOM to IN_TRANSITION', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            characterInRoom.state = {
-                mode: 'IN_ROOM',
-                room: 'another-room'
-            };
-            const startTransitionToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'do_transition';
-            }).args[1];
-            startTransitionToRoomCallback({ roomId: 'room-id' });
-            expect(
-                characterInRoom.state,
-                'state does not match'
-            ).to.deep.equal({ mode: 'IN_TRANSITION', from: 'another-room', to: 'room-id' });
-            expect(
-                gameEventEmitterStub.emit.calledWith('leaving_room'),
-                'leaving_room not emitted'
-            ).to.equal(true);
-        });
-        it('should throw if transtioning while in transition', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            characterInRoom.state = {
-                mode: 'IN_TRANSITION',
-                from: 'another-room',
-                to: 'room-id'
-            };
-            const startTransitionToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'do_transition';
-            }).args[1];
-            expect(() =>
-                startTransitionToRoomCallback({ roomId: 'room-id' })
-            ).to.throw('Doing transition with incompatible CharacterInRoom mode IN_TRANSITION');
-        });
-    });
-    describe('instant transition to room', () => {
-        it('should go from NOT_IN_ROOM to IN_ROOM directly', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            const doInstantTransitionCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'do_instant_transition';
-            }).args[1];
-            doInstantTransitionCallback({ roomId: 'room-id' });
-            expect(
-                characterInRoom.state,
-                'state does not match'
-            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
-            expect(
-                gameEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
-                'arrived_in_room not emitted with room-id'
-            ).to.equal(true);
-        });
-        it('should go from IN_ROOM to IN_ROOM', function () {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            characterInRoom.state = {
-                mode: 'IN_ROOM',
-                room: 'another-room'
-            };
-            const doInstantTransitionCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'do_instant_transition';
-            }).args[1];
-            doInstantTransitionCallback({ roomId: 'room-id' });
-            expect(
-                characterInRoom.state,
-                'state does not match'
-            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
-            expect(
-                gameEventEmitterStub.emit.calledWith('left_room', 'another-room'),
-                'left_room not emitted with another-room'
-            ).to.equal(true);
-            expect(
-                gameEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
-                'arrived_in_room not emitted with room-id'
-            ).to.equal(true);
-        });
-    });
-    describe('moveCharacterFromTransitToRoom', () => {
-        it('should move character from IN_TRANSITION to IN_ROOM', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            characterInRoom.state = {
-                mode: 'IN_TRANSITION',
-                from: 'another-room',
-                to: 'room-id'
-            };
-            const roomFadeOutDoneCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'room_fade_out_done';
-            }).args[1];
-            roomFadeOutDoneCallback();
-            expect(
-                characterInRoom.state,
-                'state does not match'
-            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
-            expect(
-                gameEventEmitterStub.emit.calledWith('left_room', 'another-room'),
-                'left_room not emitted with another-room'
-            ).to.equal(true);
-            expect(
-                gameEventEmitterStub.emit.calledWith('arriving_in_room'),
-                'arriving_in_room not emitted'
-            ).to.equal(true);
-            expect(
-                gameEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
-                'arrived_in_room not emitted with room-id'
-            ).to.equal(true);
-        });
-        it('should throw if finishing transtioning while already in a room', () => {
-            const characterInRoom = new CharacterInRoom(uiEventEmitterStub, gameEventEmitterStub);
-            characterInRoom.state = {
-                mode: 'IN_ROOM',
-                room: 'room-id'
-            };
-            const roomFadeOutDoneCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'room_fade_out_done';
-            }).args[1];
-            expect(() =>
-                roomFadeOutDoneCallback()
-            ).to.throw('Moving character from in transition to room with incompatible mode IN_ROOM');
         });
     });
 });

--- a/src/view/inventory/InventoryView.js
+++ b/src/view/inventory/InventoryView.js
@@ -5,14 +5,12 @@ import InventoryItemsView from "./InventoryItemsView.js"
 class InventoryView {
     /**
      * @param {EventEmitter} uiEventEmitter
-     * @param {EventEmitter} gameEventEmitter
      * @param {StageObjectGetter} stageObjectGetter
      * @param {Konva.Layer} inventoryBarLayer
      * @param {InventoryItemsView} inventoryItemsView
      */
-    constructor(uiEventEmitter, gameEventEmitter, stageObjectGetter, inventoryBarLayer, inventoryItemsView) {
+    constructor(uiEventEmitter, stageObjectGetter, inventoryBarLayer, inventoryItemsView) {
         this.uiEventEmitter = uiEventEmitter;
-        this.gameEventEmitter = gameEventEmitter;
         this.stageObjectGetter = stageObjectGetter;
         this.inventoryBarLayer = inventoryBarLayer;
         this.inventoryItemsView = inventoryItemsView;
@@ -23,7 +21,7 @@ class InventoryView {
         this.uiEventEmitter.on('inventory_view_model_updated', ({ visibleInventoryItems, isLeftArrowVisible, isRightArrowVisible }) => {
             this.redrawInventory(visibleInventoryItems, isLeftArrowVisible, isRightArrowVisible);
         });
-        this.gameEventEmitter.on('arrived_in_room', (roomId) => {
+        this.uiEventEmitter.on('arrived_in_room', (roomId) => {
             this.handleArrivedInRoom(roomId);
         });
         this.uiEventEmitter.on('inventory_left_arrow_draghovered', () => {

--- a/src/view/inventory/InventoryView.test.js
+++ b/src/view/inventory/InventoryView.test.js
@@ -10,7 +10,6 @@ const { Shape, Layer } = pkg;
 use(sinonChai);
 
 describe('inventory view tests', () => {
-    let gameEventEmitterStub;
     let uiEventEmitterStub;
     let stageObjectGetterStub;
     let inventoryBarLayerStub;
@@ -18,7 +17,6 @@ describe('inventory view tests', () => {
     let leftArrowStub;
     let rightArrowStub;
     beforeEach(() => {
-        gameEventEmitterStub = createStubInstance(EventEmitter);
         uiEventEmitterStub = createStubInstance(EventEmitter);
         stageObjectGetterStub = createStubInstance(StageObjectGetter);
         leftArrowStub = createStubInstance(Shape);
@@ -35,7 +33,6 @@ describe('inventory view tests', () => {
         it('should redraw inventory on inventory_view_model_updated', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
@@ -57,7 +54,6 @@ describe('inventory view tests', () => {
         it('should show both arrows if requested', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
@@ -73,7 +69,6 @@ describe('inventory view tests', () => {
         it('should show only right arrow if requested', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
@@ -89,7 +84,6 @@ describe('inventory view tests', () => {
         it('should show only left arrow if requested', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
@@ -110,12 +104,11 @@ describe('inventory view tests', () => {
             });
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
             );
-            const handleArrivedInRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+            const handleArrivedInRoomCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'arrived_in_room';
             }).args[1];
             handleArrivedInRoomCallback('room-id');
@@ -128,12 +121,11 @@ describe('inventory view tests', () => {
             });
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
             );
-            const handleArrivedInRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+            const handleArrivedInRoomCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'arrived_in_room';
             }).args[1];
             handleArrivedInRoomCallback('room-id');
@@ -145,7 +137,6 @@ describe('inventory view tests', () => {
         it('should handle drag move hover on object', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub
@@ -166,7 +157,6 @@ describe('inventory view tests', () => {
         it('should handle drag move hover on nothing', () => {
             new InventoryView(
                 uiEventEmitterStub,
-                gameEventEmitterStub,
                 stageObjectGetterStub,
                 inventoryBarLayerStub,
                 inventoryItemsViewStub

--- a/src/view/music/Music.js
+++ b/src/view/music/Music.js
@@ -8,7 +8,7 @@ class Music {
      * @param {EventEmitter} uiEventEmitter
      * @param {EventEmitter} gameEventEmitter
      */
-    constructor(musicJson, audioFactory, uiEventEmitter, gameEventEmitter) {
+    constructor(musicJson, audioFactory, uiEventEmitter) {
         this.musicJson = musicJson;
         this.audioFactory = audioFactory;
         this.current_audio = null;
@@ -21,7 +21,7 @@ class Music {
             this.playMusicById(sequenceId);
         });
         // Assumes room music is in musicJson with the roomId
-        gameEventEmitter.on('arrived_in_room', (roomId) => {
+        uiEventEmitter.on('arrived_in_room', (roomId) => {
             this.playMusicById(roomId);
         });
     }

--- a/src/view/music/Music.test.js
+++ b/src/view/music/Music.test.js
@@ -11,13 +11,11 @@ class AudioStub {
 
 describe('test Music methods', function () {
     let uiEventEmitterStub;
-    let gameEventEmitterStub;
     let audioFactoryStub;
     let audioStubStub;
 
     beforeEach(() => {
         uiEventEmitterStub = createStubInstance(EventEmitter);
-        gameEventEmitterStub = createStubInstance(EventEmitter);
         audioFactoryStub = createStubInstance(AudioFactory);
         audioStubStub = createStubInstance(AudioStub, { play: null, pause: null });
         audioFactoryStub.create.returns(audioStubStub);
@@ -31,7 +29,7 @@ describe('test Music methods', function () {
                 "music": "music.ogg",
             },
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusic(undefined);
         assert(audioStubStub.play.notCalled);
         const current_audio = music.current_audio;
@@ -43,7 +41,7 @@ describe('test Music methods', function () {
                 "music": "music.ogg",
             },
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusicById("layer");
         assert(audioStubStub.play.called, "play not called for first music");
         const current_audio = music.current_audio;
@@ -61,7 +59,7 @@ describe('test Music methods', function () {
                 "music": "music.ogg",
             },
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusicById('layer');
         const result = music.current_audio;
         assert.isNotNull(result);
@@ -79,7 +77,7 @@ describe('test Music methods', function () {
                 "loop": false,
             },
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusicById('layer');
         assert(audioStubStub.play.called);
         const result = music.current_audio;
@@ -99,7 +97,7 @@ describe('test Music methods', function () {
                 "music": "music.ogg"
             }
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusicById('loop');
         assert(audioStubStub.play.called);
         const audioStubStubNotToBeCreated = createStubInstance(AudioStub, { play: null, pause: null });
@@ -120,7 +118,7 @@ describe('test Music methods', function () {
                 "loop": false
             }
         };
-        const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
         music.playMusicById('loop');
         assert(audioStubStub.play.called);
         const audioStubStubNotToBeCreated = createStubInstance(AudioStub, { play: null, pause: null });
@@ -148,7 +146,7 @@ describe('test Music methods', function () {
                     "loop": true,
                 },
             };
-            const music = new Music(json, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+            const music = new Music(json, audioFactoryStub, uiEventEmitterStub);
             music.playMusicById('layer');
             assert(audioStubStub.play.called);
             const result = music.current_audio;
@@ -173,13 +171,11 @@ describe('test Music methods', function () {
  */
 describe('test Music event management', function () {
     let uiEventEmitterStub;
-    let gameEventEmitterStub;
     let audioFactoryStub;
     let audioStubStub;
 
     beforeEach(() => {
         uiEventEmitterStub = createStubInstance(EventEmitter);
-        gameEventEmitterStub = createStubInstance(EventEmitter);
         audioFactoryStub = createStubInstance(AudioFactory);
         audioStubStub = createStubInstance(AudioStub, { play: null, pause: null });
         audioFactoryStub.create.returns(audioStubStub);
@@ -189,7 +185,7 @@ describe('test Music event management', function () {
     });
     it('should handle play_music event by calling playMusic', function () {
         const playMusicStub = stub(Music.prototype, 'playMusic');
-        new Music({}, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        new Music({}, audioFactoryStub, uiEventEmitterStub);
         const musicData = { music: 'test.ogg' };
         const playMusicCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
             return callback.args[0] === 'play_music';
@@ -199,7 +195,7 @@ describe('test Music event management', function () {
     });
     it('should handle play_sequence_started event by calling playMusicById', function () {
         const playMusicByIdStub = stub(Music.prototype, 'playMusicById');
-        new Music({}, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        new Music({}, audioFactoryStub, uiEventEmitterStub);
         const musicId = 'testId';
         const playMusicByIdCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
             return callback.args[0] === 'play_sequence_started';
@@ -209,9 +205,9 @@ describe('test Music event management', function () {
     });
     it('should handle arrived_in_room event by calling playMusicById', function () {
         const playMusicByIdStub = stub(Music.prototype, 'playMusicById');
-        new Music({}, audioFactoryStub, uiEventEmitterStub, gameEventEmitterStub);
+        new Music({}, audioFactoryStub, uiEventEmitterStub);
         const roomId = 'testId';
-        const playMusicByIdCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+        const playMusicByIdCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
             return callback.args[0] === 'arrived_in_room';
         }).args[1];
         playMusicByIdCallback(roomId);

--- a/src/view/room/CharacterInRoomViewModel.js
+++ b/src/view/room/CharacterInRoomViewModel.js
@@ -1,0 +1,100 @@
+class CharacterInRoomViewModel {
+    constructor(uiEventEmitter, gameEventEmitter) {
+        this.uiEventEmitter = uiEventEmitter;
+        this.gameEventEmitter = gameEventEmitter;
+        this.state = {
+            mode: 'NOT_IN_ROOM'
+        };
+        this.uiEventEmitter.on('room_fade_out_done', () => {
+            this.moveCharacterFromTransitToRoom();
+        });
+        this.uiEventEmitter.on('ready_transition', ({ type, roomId }) => {
+            this.readyTransition(type, roomId);
+        });
+        this.gameEventEmitter.on('character_moved_to_room', ({ roomId }) => {
+            this.resolveCharacterMovedToRoom(roomId);
+        });
+    }
+
+    readyTransition(type, roomId) {
+        if (this.state.mode !== 'NOT_IN_ROOM' && this.state.mode !== 'IN_ROOM') {
+            throw new Error('Resolving ready_transition with incompatible CharacterInRoom mode ' + this.state.mode);
+        }
+        const transitionType = this.state.mode === 'NOT_IN_ROOM' ? 'instant' : type;
+        const from = this.state.mode === 'IN_ROOM' ? this.state.room : null;
+        this.state = {
+            mode: 'READY_TO_LEAVE',
+            transitionType,
+            from,
+            to: roomId
+        };
+    }
+
+    resolveCharacterMovedToRoom(roomId) {
+        if (this.state.mode !== 'READY_TO_LEAVE') {
+            throw new Error('Resolving character_moved_to_room with incompatible CharacterInRoom mode ' + this.state.mode);
+        }
+        if (this.state.transitionType === 'instant') {
+            this.doInstantTransition(roomId);
+            return;
+        }
+        this.startTransitionToRoom(roomId);
+    }
+
+    /**
+     * Transition to a room.
+     * @param {string} roomId The id of the room to transition to.
+     */
+    startTransitionToRoom(roomId) {
+        if (this.state.mode !== 'READY_TO_LEAVE') {
+            throw new Error('Starting transition with incompatible CharacterInRoom mode ' + this.state.mode);
+        }
+        const from = this.state.from;
+        this.state = {
+            mode: 'IN_TRANSITION',
+            from,
+            to: roomId
+        };
+        this.uiEventEmitter.emit('leaving_room');
+    }
+
+    /**
+     * Transition to a room without ... transitioning.
+     * @param {string} roomId room id to move instantly to
+     */
+    doInstantTransition(roomId) {
+        if (this.state.mode !== 'READY_TO_LEAVE') {
+            throw new Error('Starting instant transition with incompatible CharacterInRoom mode ' + this.state.mode);
+        }
+        if (this.state.from) {
+            this.uiEventEmitter.emit('left_room', this.state.from);
+        }
+        this.state = {
+            mode: 'IN_ROOM',
+            room: roomId
+        };
+        this.uiEventEmitter.emit('arrived_in_room', roomId);
+    }
+
+    /**
+     * Move the character from "in transition" state to the room.
+     * @returns {void}
+     */
+    moveCharacterFromTransitToRoom() {
+        if (this.state.mode !== 'IN_TRANSITION') {
+            throw new Error('Moving character from in transition to room with incompatible mode ' + this.state.mode);
+        };
+        const from = this.state.from;
+        const room = this.state.to;
+        this.state = {
+            mode: 'IN_ROOM',
+            room
+        };
+        this.uiEventEmitter.emit('left_room', from);
+        this.uiEventEmitter.emit('arriving_in_room');
+        this.uiEventEmitter.emit('arrived_in_room', room);
+        return;
+    }
+};
+
+export default CharacterInRoomViewModel;

--- a/src/view/room/CharacterInRoomViewModel.test.js
+++ b/src/view/room/CharacterInRoomViewModel.test.js
@@ -1,0 +1,178 @@
+import { expect } from 'chai';
+import { createStubInstance } from 'sinon';
+import CharacterInRoomViewModel from './CharacterInRoomViewModel.js';
+import EventEmitter from '../../events/EventEmitter.js';
+
+describe('Character in room view model tests', () => {
+    let uiEventEmitterStub;
+    let gameEventEmitterStub;
+    beforeEach(() => {
+        uiEventEmitterStub = createStubInstance(EventEmitter);
+        gameEventEmitterStub = createStubInstance(EventEmitter);
+    });
+    describe('ready transition', () => {
+        it('should go from NOT_IN_ROOM to READY_TO_LEAVE with setting from to null', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            const readyTransitionCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'ready_transition';
+            }).args[1];
+            readyTransitionCallback({ type: 'instant', roomId: 'roomy_room' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'READY_TO_LEAVE', transitionType: 'instant', from: null, to: 'roomy_room' });
+        });
+        it('should override transition type to instant when going from NOT_IN_ROOM to READY_TO_LEAVE', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            const readyTransitionCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'ready_transition';
+            }).args[1];
+            readyTransitionCallback({ type: 'regular', roomId: 'roomy_room' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'READY_TO_LEAVE', transitionType: 'instant', from: null, to: 'roomy_room' });
+        });
+        it('should set READY_TO_LEAVE from IN_ROOM with from with room id and the given type', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'IN_ROOM',
+                room: 'previous_room'
+            };
+            const readyTransitionCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'ready_transition';
+            }).args[1];
+            readyTransitionCallback({ type: 'regular', roomId: 'roomy_room' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'READY_TO_LEAVE', transitionType: 'regular', from: 'previous_room', to: 'roomy_room' });
+        });
+    });
+    describe('resolve character_moved_to_room', () => {
+        it('should go to IN_ROOM directly with transitionType instant and null from', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'READY_TO_LEAVE',
+                transitionType: 'instant',
+                from: null,
+                to: 'room-id'
+            }
+            const resolveCharacterMovedToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'character_moved_to_room';
+            }).args[1];
+            resolveCharacterMovedToRoomCallback({ roomId: 'room-id' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
+            expect(
+                uiEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
+                'arrived_in_room not emitted with room_id'
+            ).to.equal(true);
+        });
+        it('should go to IN_ROOM directly with transitionType instant and from defined', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'READY_TO_LEAVE',
+                transitionType: 'instant',
+                from: 'previous_room',
+                to: 'room-id'
+            }
+            const resolveCharacterMovedToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'character_moved_to_room';
+            }).args[1];
+            resolveCharacterMovedToRoomCallback({ roomId: 'room-id' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
+            expect(
+                uiEventEmitterStub.emit.calledWith('left_room', 'previous_room'),
+                'left_room not emitted with previous_room'
+            ).to.equal(true);
+            expect(
+                uiEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
+                'arrived_in_room not emitted with room_id'
+            ).to.equal(true);
+        });
+        it('should go from READY_TO_LEAVE with from to IN_TRANSITION with type regular', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'READY_TO_LEAVE',
+                transitionType: 'regular',
+                from: 'previous_room',
+                to: 'room-id'
+            };
+            const resolveCharacterMovedToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'character_moved_to_room';
+            }).args[1];
+            resolveCharacterMovedToRoomCallback({ roomId: 'room-id' });
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'IN_TRANSITION', from: 'previous_room', to: 'room-id' });
+            expect(
+                uiEventEmitterStub.emit.calledWith('leaving_room'),
+                'leaving_room not emitted'
+            ).to.equal(true);
+        });
+        it('should throw if resolving character_moved_to_room while in transition', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'IN_TRANSITION',
+                from: 'another-room',
+                to: 'room-id'
+            };
+            const resolveCharacterMovedToRoomCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'character_moved_to_room';
+            }).args[1];
+            expect(() =>
+                resolveCharacterMovedToRoomCallback({ roomId: 'room-id' })
+            ).to.throw('Resolving character_moved_to_room with incompatible CharacterInRoom mode IN_TRANSITION');
+        });
+    });
+    describe('moveCharacterFromTransitToRoom', () => {
+        it('should move character from IN_TRANSITION to IN_ROOM', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'IN_TRANSITION',
+                from: 'another-room',
+                to: 'room-id'
+            };
+            const roomFadeOutDoneCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'room_fade_out_done';
+            }).args[1];
+            roomFadeOutDoneCallback();
+            expect(
+                characterInRoom.state,
+                'state does not match'
+            ).to.deep.equal({ mode: 'IN_ROOM', room: 'room-id' });
+            expect(
+                uiEventEmitterStub.emit.calledWith('left_room', 'another-room'),
+                'left_room not emitted with another-room'
+            ).to.equal(true);
+            expect(
+                uiEventEmitterStub.emit.calledWith('arriving_in_room'),
+                'arriving_in_room not emitted'
+            ).to.equal(true);
+            expect(
+                uiEventEmitterStub.emit.calledWith('arrived_in_room', 'room-id'),
+                'arrived_in_room not emitted with room-id'
+            ).to.equal(true);
+        });
+        it('should throw if finishing transtioning while already in a room', () => {
+            const characterInRoom = new CharacterInRoomViewModel(uiEventEmitterStub, gameEventEmitterStub);
+            characterInRoom.state = {
+                mode: 'IN_ROOM',
+                room: 'room-id'
+            };
+            const roomFadeOutDoneCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
+                return callback.args[0] === 'room_fade_out_done';
+            }).args[1];
+            expect(() =>
+                roomFadeOutDoneCallback()
+            ).to.throw('Moving character from in transition to room with incompatible mode IN_ROOM');
+        });
+    });
+});

--- a/src/view/room/RoomAnimations.js
+++ b/src/view/room/RoomAnimations.js
@@ -3,15 +3,16 @@ import EventEmitter from "../../events/EventEmitter.js";
 class RoomAnimations {
     /**
      * @param {EventEmitter} gameEventEmitter
+     * @param {EventEmitter} uiEventEmitter
      * @param {Konva.Tween[]} animatedObjects
      */
-    constructor(gameEventEmitter, animatedObjects) {
+    constructor(gameEventEmitter, uiEventEmitter, animatedObjects) {
         this.animatedObjects = animatedObjects;
         this.runningAnimations = new Set();
-        gameEventEmitter.on('remove_object', (objectName) => {
-            this.removeAnimation(objectName);
+        gameEventEmitter.on('removed_objects', ({ objectList: _objectList, objectsRemoved }) => {
+            this.removeAnimations(objectsRemoved);
         });
-        gameEventEmitter.on('arrived_in_room', (roomId) => {
+        uiEventEmitter.on('arrived_in_room', (roomId) => {
             this.playRoomAnimations(roomId);
         });
     }
@@ -32,12 +33,12 @@ class RoomAnimations {
     }
 
     /**
-     * Remove an object from the list of animated objects
-     * @param {string} id The id of the object to be de-animated
+     * Removes objects from the list of animated objects
+     * @param {string[]} ids The ids of the object to be de-animated
      */
-    removeAnimation(id) {
+    removeAnimations(ids) {
         this.animatedObjects = this.animatedObjects.filter((animatedObject) => {
-            return animatedObject.node.id() !== id;
+            return !ids.includes(animatedObject.node.id());
         });
     }
 }

--- a/src/view/room/RoomAnimations.test.js
+++ b/src/view/room/RoomAnimations.test.js
@@ -7,8 +7,10 @@ const { Container, Node, Animation } = pkg;
 
 describe('Room animations player tests', function () {
     let gameEventEmitterStub;
+    let uiEventEmitterStub;
     beforeEach(() => {
         gameEventEmitterStub = createStubInstance(EventEmitter);
+        uiEventEmitterStub = createStubInstance(EventEmitter);
     });
     afterEach(() => {
         restore();
@@ -27,8 +29,8 @@ describe('Room animations player tests', function () {
     };
     describe('play room animations', function () {
         it('should start the room animations when entering the room', function () {
-            const roomAnimations = new RoomAnimations(gameEventEmitterStub);
-            const playRoomAnimationsCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+            const roomAnimations = new RoomAnimations(gameEventEmitterStub, uiEventEmitterStub, []);
+            const playRoomAnimationsCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'arrived_in_room';
             }).args[1];
             const { mockTween, mockAnimation } = buildMockTween('room-id', 'node-id');
@@ -38,8 +40,8 @@ describe('Room animations player tests', function () {
             assert.isFalse(mockAnimation.stop.called);
         });
         it('should stop previous room\'s animations when entering the next room', function () {
-            const roomAnimations = new RoomAnimations(gameEventEmitterStub);
-            const playRoomAnimationsCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+            const roomAnimations = new RoomAnimations(gameEventEmitterStub, uiEventEmitterStub, []);
+            const playRoomAnimationsCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'arrived_in_room';
             }).args[1];
             const { mockTween: mockFirstRoomTween, mockAnimation: mockFirstRoomAnimation } = buildMockTween('room-id', 'first-node-id');
@@ -53,18 +55,18 @@ describe('Room animations player tests', function () {
             assert.isFalse(mockSecondRoomAnimation.stop.called);
         });
     });
-    describe('remove animations', function () {
-        it('should not play animation after removing it from the room', function () {
-            const roomAnimations = new RoomAnimations(gameEventEmitterStub);
-            const playRoomAnimationsCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
+    describe('remove animations', () => {
+        it('should not play animation after removing it from the room', () => {
+            const roomAnimations = new RoomAnimations(gameEventEmitterStub, uiEventEmitterStub, []);
+            const playRoomAnimationsCallback = uiEventEmitterStub.on.getCalls().find((callback) => {
                 return callback.args[0] === 'arrived_in_room';
             }).args[1];
             const { mockTween } = buildMockTween('room-id', 'node-id');
             roomAnimations.animatedObjects = [mockTween];
             const removeObjectCallback = gameEventEmitterStub.on.getCalls().find((callback) => {
-                return callback.args[0] === 'remove_object';
+                return callback.args[0] === 'removed_objects';
             }).args[1];
-            removeObjectCallback('node-id');
+            removeObjectCallback({ objectList: {/* irrelevant for test */}, objectsRemoved: ['node-id'] });
             playRoomAnimationsCallback('room-id');
             assert.isFalse(mockTween.play.calledOnce, 'removed tween was played');
         });

--- a/src/view/room/RoomFader.js
+++ b/src/view/room/RoomFader.js
@@ -1,5 +1,5 @@
 class RoomFader {
-    constructor(faderNode, uiEventEmitter, gameEventEmitter) {
+    constructor(faderNode, uiEventEmitter) {
         this.faderNode = faderNode;
         // Should we have a Tween factory?
         this.animation =  new Konva.Tween({
@@ -9,12 +9,11 @@ class RoomFader {
         });
 
         this.uiEventEmitter = uiEventEmitter;
-        this.gameEventEmitter = gameEventEmitter;
 
-        this.gameEventEmitter.on('leaving_room', () => {
+        this.uiEventEmitter.on('leaving_room', () => {
             this.roomFadeOut();
         });
-        this.gameEventEmitter.on('arriving_in_room', () => {
+        this.uiEventEmitter.on('arriving_in_room', () => {
             this.roomFadeIn();
         });
     }

--- a/src/view/room/RoomView.js
+++ b/src/view/room/RoomView.js
@@ -45,13 +45,13 @@ class RoomView {
         this.uiEventEmitter.on('inventory_redrawn', () => {
             this.drawRoomLayer();
         });
-
-        this.gameEventEmitter.on('left_room', (from) => {
+        this.uiEventEmitter.on('left_room', (from) => {
             this.hidePreviousRoom(from);
         });
-        this.gameEventEmitter.on('arrived_in_room', (roomId) => {
+        this.uiEventEmitter.on('arrived_in_room', (roomId) => {
             this.showRoom(roomId);
         });
+
         this.gameEventEmitter.on('removed_objects', ({ objectList: _objectList, objectsRemoved}) => {
             this.removeObject(objectsRemoved);
         });


### PR DESCRIPTION
Turns out moving events from gameEventEmitter to uiEventEmitter makes for quite a refactoring.

Also fixes removing room animations on removed_objects event.